### PR TITLE
Carve out new release version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Library for ANSI terminal colors and styles (bold, underline)"
 edition = "2018"
 license = "MIT"
 name = "nu-ansi-term"
-version = "0.44.0"
+version = "0.45.0"
 
 [lib]
 doctest = false

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This crate works with [Cargo](http://crates.io). Add the following to your `Carg
 
 ```toml
 [dependencies]
-nu_ansi_term = "0.13"
+nu_ansi_term = "0.45"
 ```
 
 ## Basic usage


### PR DESCRIPTION
Does not effectively change the code base.
nu-ansi-term can now be used without being in lockstep with
nushell/nushell