### PR TITLE
Remove `impl Deref` for `AnsiGenericString`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Library for ANSI terminal colors and styles (bold, underline)"
 edition = "2018"
 license = "MIT"
 name = "nu-ansi-term"
-version = "0.45.1"
+version = "0.46.0"
 repository = "https://github.com/nushell/nu-ansi-term"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 This is a library for controlling colors and formatting, such as red bold text or blue underlined text, on ANSI terminals.
 
-### [View the Rustdoc](https://docs.rs/nu_ansi_term/)
+## [View the Rustdoc](https://docs.rs/nu_ansi_term/)
 
-# Installation
+## Installation
 
 This crate works with [Cargo](http://crates.io). Add the following to your `Cargo.toml` dependencies section:
 

--- a/src/display.rs
+++ b/src/display.rs
@@ -5,7 +5,6 @@ use crate::write::AnyWrite;
 use std::borrow::Cow;
 use std::fmt;
 use std::io;
-use std::ops::Deref;
 
 /// An `AnsiGenericString` includes a generic string type and a `Style` to
 /// display that string.  `AnsiString` and `AnsiByteString` are aliases for
@@ -15,8 +14,8 @@ pub struct AnsiGenericString<'a, S: 'a + ToOwned + ?Sized>
 where
     <S as ToOwned>::Owned: fmt::Debug,
 {
-    style: Style,
-    string: Cow<'a, S>,
+    pub(crate) style: Style,
+    pub(crate) string: Cow<'a, S>,
 }
 
 /// Cloning an `AnsiGenericString` will clone its underlying string.
@@ -83,7 +82,6 @@ where
 /// use nu_ansi_term::AnsiString;
 ///
 /// let plain_string = AnsiString::from("a plain string");
-/// assert_eq!(&*plain_string, "a plain string");
 /// ```
 pub type AnsiString<'a> = AnsiGenericString<'a, str>;
 
@@ -116,17 +114,6 @@ where
     /// Directly access the style mutably
     pub fn style_ref_mut(&mut self) -> &mut Style {
         &mut self.style
-    }
-}
-
-impl<'a, S: 'a + ToOwned + ?Sized> Deref for AnsiGenericString<'a, S>
-where
-    <S as ToOwned>::Owned: fmt::Debug,
-{
-    type Target = S;
-
-    fn deref(&self) -> &S {
-        self.string.deref()
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -12,8 +12,7 @@ pub fn sub_string<'a>(
     let mut len_rem = len;
 
     for i in strs.0.iter() {
-        let fragment = i.deref();
-        let frag_len = fragment.len();
+        let frag_len = i.string.len();
         if pos >= frag_len {
             pos -= frag_len;
             continue;
@@ -25,7 +24,7 @@ pub fn sub_string<'a>(
         let end = pos + len_rem;
         let pos_end = if end >= frag_len { frag_len } else { end };
 
-        vec.push(i.style_ref().paint(String::from(&fragment[pos..pos_end])));
+        vec.push(i.style_ref().paint(String::from(&i.string[pos..pos_end])));
 
         if end <= frag_len {
             break;
@@ -43,7 +42,7 @@ pub fn unstyle(strs: &AnsiStrings) -> String {
     let mut s = String::new();
 
     for i in strs.0.iter() {
-        s += i.deref();
+        s += i.string.deref();
     }
 
     s
@@ -53,7 +52,7 @@ pub fn unstyle(strs: &AnsiStrings) -> String {
 pub fn unstyled_len(strs: &AnsiStrings) -> usize {
     let mut l = 0;
     for i in strs.0.iter() {
-        l += i.deref().len();
+        l += i.string.len();
     }
     l
 }


### PR DESCRIPTION
The `Deref` implementation for `AnsiGenericString` and its derived type aliases probably violates the tacit definition of the `Deref` trait:

https://doc.rust-lang.org/std/ops/trait.Deref.html

As the type aliases implement `Display` for the actual styling logic they get a blanket `impl ToString for T: Display + ?Sized`

This has the nasty consequence that while you would expect that `fn foo(input: AsRef<str>)` would get the same input from `let styled: AnsiGenericString<_> = ...` for both `foo(styled)` and `foo(styled.to_string())` this doesn't hold.

Thus the lint <https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_to_owned> will change the actual behavior and remove styling as the underlying string gets presented via `Deref`.

This change removes the `Deref` implementation and fixes the internal uses.

