### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This crate works with [Cargo](http://crates.io). Add the following to your `Carg
 
 ```toml
 [dependencies]
-nu_ansi_term = "0.46"
+nu-ansi-term = "0.46"
 ```
 
 ## Basic usage


### PR DESCRIPTION
update readme for Cargo.toml file to reflect registered rust crate name is `nu-ansi-term` and not 'nu_ansi_term'