### PR TITLE
Allow dereferencing AnsiString as underlying string

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -115,6 +115,11 @@ where
     pub fn style_ref_mut(&mut self) -> &mut Style {
         &mut self.style
     }
+
+    // Directly access the underlying string
+    pub fn as_str(&self) -> &S {
+        self.string.as_ref()
+    }
 }
 
 /// A set of `AnsiGenericStrings`s collected together, in order to be


### PR DESCRIPTION
Hello, I've been in process of converting https://github.com/ogham/exa from `rust-ansi-term` to `nu-ansi-term` and there is one api that exa needs that was lost during the refactoring from rust-ansi-term to nu-ansi-term.

`exa` needs the underlying raw string to calculate widths, previously this api was present in a form, where AnsiString could be dereferenced into `Cow<'a, str>`, directly and the to str, which was then used.

This adds the minimal required code, it just returns `&str` which is the minimum needed.

I tried to workaround this with some other api but could not found any in `nu-ansi-term` and `to_string` would require allocation which seemed unnecessary as the underlying view can be returned directly.