### PR TITLE
Implement the provided operators for `Rgb` manually

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ doctest = true
 derive_serde_style = ["serde"]
 
 [dependencies]
-overload = "0.1.1"
 serde = { version="1.0.90", features=["derive"], optional=true }
 
 [target.'cfg(target_os="windows")'.dependencies.winapi]

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -146,14 +146,6 @@ fn rgb_mul_f32(lhs: &Rgb, rhs: &f32) -> Rgb {
     )
 }
 
-fn f32_mul_rgb(lhs: &f32, rhs: &Rgb) -> Rgb {
-    Rgb::new(
-        (rhs.r as f32 * lhs.clamp(0.0, 1.0)) as u8,
-        (rhs.g as f32 * lhs.clamp(0.0, 1.0)) as u8,
-        (rhs.b as f32 * lhs.clamp(0.0, 1.0)) as u8,
-    )
-}
-
 fn rgb_negate(rgb: &Rgb) -> Rgb {
     Rgb::new(255 - rgb.r, 255 - rgb.g, 255 - rgb.b)
 }
@@ -258,7 +250,7 @@ impl std::ops::Mul<Rgb> for f32 {
     type Output = Rgb;
 
     fn mul(self, rhs: Rgb) -> Self::Output {
-        f32_mul_rgb(&self, &rhs)
+        rgb_mul_f32(&rhs, &self)
     }
 }
 
@@ -266,7 +258,7 @@ impl std::ops::Mul<&Rgb> for f32 {
     type Output = Rgb;
 
     fn mul(self, rhs: &Rgb) -> Self::Output {
-        f32_mul_rgb(&self, rhs)
+        rgb_mul_f32(rhs, &self)
     }
 }
 
@@ -274,7 +266,7 @@ impl std::ops::Mul<Rgb> for &f32 {
     type Output = Rgb;
 
     fn mul(self, rhs: Rgb) -> Self::Output {
-        f32_mul_rgb(self, &rhs)
+        rgb_mul_f32(&rhs, self)
     }
 }
 
@@ -282,7 +274,7 @@ impl std::ops::Mul<&Rgb> for &f32 {
     type Output = Rgb;
 
     fn mul(self, rhs: &Rgb) -> Self::Output {
-        f32_mul_rgb(self, rhs)
+        rgb_mul_f32(rhs, self)
     }
 }
 

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -1,6 +1,5 @@
 // Code liberally borrowed from here
 // https://github.com/navierr/coloriz
-use std::ops;
 use std::u32;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Rgb {
@@ -123,51 +122,182 @@ impl ANSIColorCode for Rgb {
     }
 }
 
-overload::overload!(
-    (lhs: ?Rgb) + (rhs: ?Rgb) -> Rgb {
-        Rgb::new(
-            lhs.r.saturating_add(rhs.r),
-            lhs.g.saturating_add(rhs.g),
-            lhs.b.saturating_add(rhs.b)
-        )
-    }
-);
+fn rgb_add(lhs: &Rgb, rhs: &Rgb) -> Rgb {
+    Rgb::new(
+        lhs.r.saturating_add(rhs.r),
+        lhs.g.saturating_add(rhs.g),
+        lhs.b.saturating_add(rhs.b),
+    )
+}
 
-overload::overload!(
-    (lhs: ?Rgb) - (rhs: ?Rgb) -> Rgb {
-        Rgb::new(
-            lhs.r.saturating_sub(rhs.r),
-            lhs.g.saturating_sub(rhs.g),
-            lhs.b.saturating_sub(rhs.b)
-        )
-    }
-);
+fn rgb_sub(lhs: &Rgb, rhs: &Rgb) -> Rgb {
+    Rgb::new(
+        lhs.r.saturating_sub(rhs.r),
+        lhs.g.saturating_sub(rhs.g),
+        lhs.b.saturating_sub(rhs.b),
+    )
+}
 
-overload::overload!(
-    (lhs: ?Rgb) * (rhs: ?f32) -> Rgb {
-        Rgb::new(
-            (lhs.r as f32 * rhs.clamp(0.0, 1.0)) as u8,
-            (lhs.g as f32 * rhs.clamp(0.0, 1.0)) as u8,
-            (lhs.b as f32 * rhs.clamp(0.0, 1.0)) as u8
-        )
-    }
-);
+fn rgb_mul_f32(lhs: &Rgb, rhs: &f32) -> Rgb {
+    Rgb::new(
+        (lhs.r as f32 * rhs.clamp(0.0, 1.0)) as u8,
+        (lhs.g as f32 * rhs.clamp(0.0, 1.0)) as u8,
+        (lhs.b as f32 * rhs.clamp(0.0, 1.0)) as u8,
+    )
+}
 
-overload::overload!(
-    (lhs: ?f32) * (rhs: ?Rgb) -> Rgb {
-        Rgb::new(
-            (rhs.r as f32 * lhs.clamp(0.0, 1.0)) as u8,
-            (rhs.g as f32 * lhs.clamp(0.0, 1.0)) as u8,
-            (rhs.b as f32 * lhs.clamp(0.0, 1.0)) as u8
-        )
-    }
-);
+fn f32_mul_rgb(lhs: &f32, rhs: &Rgb) -> Rgb {
+    Rgb::new(
+        (rhs.r as f32 * lhs.clamp(0.0, 1.0)) as u8,
+        (rhs.g as f32 * lhs.clamp(0.0, 1.0)) as u8,
+        (rhs.b as f32 * lhs.clamp(0.0, 1.0)) as u8,
+    )
+}
 
-overload::overload!(
-    -(rgb: ?Rgb) -> Rgb {
-        Rgb::new(
-            255 - rgb.r,
-            255 - rgb.g,
-            255 - rgb.b)
+fn rgb_negate(rgb: &Rgb) -> Rgb {
+    Rgb::new(255 - rgb.r, 255 - rgb.g, 255 - rgb.b)
+}
+
+impl std::ops::Add<Rgb> for Rgb {
+    type Output = Rgb;
+
+    fn add(self, rhs: Rgb) -> Self::Output {
+        rgb_add(&self, &rhs)
     }
-);
+}
+
+impl std::ops::Add<&Rgb> for Rgb {
+    type Output = Rgb;
+
+    fn add(self, rhs: &Rgb) -> Self::Output {
+        rgb_add(&self, rhs)
+    }
+}
+
+impl std::ops::Add<Rgb> for &Rgb {
+    type Output = Rgb;
+
+    fn add(self, rhs: Rgb) -> Self::Output {
+        rgb_add(self, &rhs)
+    }
+}
+
+impl std::ops::Add<&Rgb> for &Rgb {
+    type Output = Rgb;
+
+    fn add(self, rhs: &Rgb) -> Self::Output {
+        rgb_add(self, rhs)
+    }
+}
+
+impl std::ops::Sub<Rgb> for Rgb {
+    type Output = Rgb;
+
+    fn sub(self, rhs: Rgb) -> Self::Output {
+        rgb_sub(&self, &rhs)
+    }
+}
+
+impl std::ops::Sub<&Rgb> for Rgb {
+    type Output = Rgb;
+
+    fn sub(self, rhs: &Rgb) -> Self::Output {
+        rgb_sub(&self, rhs)
+    }
+}
+
+impl std::ops::Sub<Rgb> for &Rgb {
+    type Output = Rgb;
+
+    fn sub(self, rhs: Rgb) -> Self::Output {
+        rgb_sub(self, &rhs)
+    }
+}
+
+impl std::ops::Sub<&Rgb> for &Rgb {
+    type Output = Rgb;
+
+    fn sub(self, rhs: &Rgb) -> Self::Output {
+        rgb_sub(self, rhs)
+    }
+}
+
+impl std::ops::Mul<f32> for Rgb {
+    type Output = Rgb;
+
+    fn mul(self, rhs: f32) -> Self::Output {
+        rgb_mul_f32(&self, &rhs)
+    }
+}
+
+impl std::ops::Mul<&f32> for Rgb {
+    type Output = Rgb;
+
+    fn mul(self, rhs: &f32) -> Self::Output {
+        rgb_mul_f32(&self, rhs)
+    }
+}
+
+impl std::ops::Mul<f32> for &Rgb {
+    type Output = Rgb;
+
+    fn mul(self, rhs: f32) -> Self::Output {
+        rgb_mul_f32(self, &rhs)
+    }
+}
+
+impl std::ops::Mul<&f32> for &Rgb {
+    type Output = Rgb;
+
+    fn mul(self, rhs: &f32) -> Self::Output {
+        rgb_mul_f32(self, rhs)
+    }
+}
+
+impl std::ops::Mul<Rgb> for f32 {
+    type Output = Rgb;
+
+    fn mul(self, rhs: Rgb) -> Self::Output {
+        f32_mul_rgb(&self, &rhs)
+    }
+}
+
+impl std::ops::Mul<&Rgb> for f32 {
+    type Output = Rgb;
+
+    fn mul(self, rhs: &Rgb) -> Self::Output {
+        f32_mul_rgb(&self, rhs)
+    }
+}
+
+impl std::ops::Mul<Rgb> for &f32 {
+    type Output = Rgb;
+
+    fn mul(self, rhs: Rgb) -> Self::Output {
+        f32_mul_rgb(self, &rhs)
+    }
+}
+
+impl std::ops::Mul<&Rgb> for &f32 {
+    type Output = Rgb;
+
+    fn mul(self, rhs: &Rgb) -> Self::Output {
+        f32_mul_rgb(self, rhs)
+    }
+}
+
+impl std::ops::Neg for Rgb {
+    type Output = Rgb;
+
+    fn neg(self) -> Self::Output {
+        rgb_negate(&self)
+    }
+}
+
+impl std::ops::Neg for &Rgb {
+    type Output = Rgb;
+
+    fn neg(self) -> Self::Output {
+        rgb_negate(self)
+    }
+}


### PR DESCRIPTION
This removes the `overload` dependency by implementing the operators for the `Rgb` struct manually.

The `overload` macro is a bit opaque about what it generates without looking into the documentation. The generate code is fairly simple and therefore I think it's reasonable to maintain the implementation here.