### PR TITLE
Replace winapi crate with windows crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,14 @@ derive_serde_style = ["serde"]
 [dependencies]
 serde = { version="1.0.90", features=["derive"], optional=true }
 
-[target.'cfg(target_os="windows")'.dependencies.winapi]
-version = "0.3.4"
-features = ["consoleapi", "errhandlingapi", "fileapi", "handleapi", "processenv"]
+[dependencies.windows]
+version = "0.43"
+features = [
+    "Win32_Foundation",
+    "Win32_System_Console",
+    "Win32_Storage_FileSystem",
+    "Win32_Security"
+]
 
 [dev-dependencies]
 doc-comment = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,8 +236,6 @@
 #![warn(trivial_casts, trivial_numeric_casts)]
 // #![warn(unused_extern_crates, unused_qualifications)]
 
-#[cfg(target_os = "windows")]
-extern crate winapi;
 #[cfg(test)]
 #[macro_use]
 extern crate doc_comment;
@@ -258,7 +256,7 @@ pub use display::*;
 mod write;
 
 mod windows;
-pub use windows::*;
+pub use crate::windows::*;
 
 mod util;
 pub use util::*;

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,10 +2,10 @@ use crate::display::{AnsiString, AnsiStrings};
 use std::ops::Deref;
 
 /// Return a substring of the given AnsiStrings sequence, while keeping the formatting.
-pub fn sub_string<'a>(
+pub fn sub_string(
     start: usize,
     len: usize,
-    strs: &AnsiStrings<'a>,
+    strs: &AnsiStrings,
 ) -> Vec<AnsiString<'static>> {
     let mut vec = Vec::new();
     let mut pos = start;

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,11 +2,7 @@ use crate::display::{AnsiString, AnsiStrings};
 use std::ops::Deref;
 
 /// Return a substring of the given AnsiStrings sequence, while keeping the formatting.
-pub fn sub_string(
-    start: usize,
-    len: usize,
-    strs: &AnsiStrings,
-) -> Vec<AnsiString<'static>> {
+pub fn sub_string(start: usize, len: usize, strs: &AnsiStrings) -> Vec<AnsiString<'static>> {
     let mut vec = Vec::new();
     let mut pos = start;
     let mut len_rem = len;

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -9,54 +9,50 @@
 #[cfg(windows)]
 pub fn enable_ansi_support() -> Result<(), u32> {
     // ref: https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences#EXAMPLE_OF_ENABLING_VIRTUAL_TERMINAL_PROCESSING @@ https://archive.is/L7wRJ#76%
-
-    use std::ffi::OsStr;
-    use std::iter::once;
-    use std::os::windows::ffi::OsStrExt;
-    use std::ptr::null_mut;
-    use winapi::um::consoleapi::{GetConsoleMode, SetConsoleMode};
-    use winapi::um::errhandlingapi::GetLastError;
-    use winapi::um::fileapi::{CreateFileW, OPEN_EXISTING};
-    use winapi::um::handleapi::INVALID_HANDLE_VALUE;
-    use winapi::um::winnt::{FILE_SHARE_WRITE, GENERIC_READ, GENERIC_WRITE};
-
-    const ENABLE_VIRTUAL_TERMINAL_PROCESSING: u32 = 0x0004;
+    use windows::w;
+    use windows::Win32::Foundation::GetLastError;
+    use windows::Win32::Foundation::BOOL;
+    use windows::Win32::Storage::FileSystem::FILE_FLAGS_AND_ATTRIBUTES;
+    use windows::Win32::Storage::FileSystem::{CreateFileW, OPEN_EXISTING};
+    use windows::Win32::Storage::FileSystem::{
+        FILE_GENERIC_READ, FILE_GENERIC_WRITE, FILE_SHARE_WRITE,
+    };
+    use windows::Win32::System::Console::{GetConsoleMode, SetConsoleMode};
+    use windows::Win32::System::Console::{CONSOLE_MODE, ENABLE_VIRTUAL_TERMINAL_PROCESSING};
 
     unsafe {
         // ref: https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew
         // Using `CreateFileW("CONOUT$", ...)` to retrieve the console handle works correctly even if STDOUT and/or STDERR are redirected
-        let console_out_name: Vec<u16> =
-            OsStr::new("CONOUT$").encode_wide().chain(once(0)).collect();
-        let console_handle = CreateFileW(
-            console_out_name.as_ptr(),
-            GENERIC_READ | GENERIC_WRITE,
+        if let Ok(console_handle) = CreateFileW(
+            w!("CONOUT$"),
+            FILE_GENERIC_READ | FILE_GENERIC_WRITE,
             FILE_SHARE_WRITE,
-            null_mut(),
+            None,
             OPEN_EXISTING,
-            0,
-            null_mut(),
-        );
-        if console_handle == INVALID_HANDLE_VALUE {
-            return Err(GetLastError());
-        }
-
-        // ref: https://docs.microsoft.com/en-us/windows/console/getconsolemode
-        let mut console_mode: u32 = 0;
-        if 0 == GetConsoleMode(console_handle, &mut console_mode) {
-            return Err(GetLastError());
-        }
-
-        // VT processing not already enabled?
-        if console_mode & ENABLE_VIRTUAL_TERMINAL_PROCESSING == 0 {
-            // https://docs.microsoft.com/en-us/windows/console/setconsolemode
-            if 0 == SetConsoleMode(
-                console_handle,
-                console_mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING,
-            ) {
-                return Err(GetLastError());
+            FILE_FLAGS_AND_ATTRIBUTES(0),
+            None,
+        ) {
+            // ref: https://docs.microsoft.com/en-us/windows/console/getconsolemode
+            let mut console_mode = CONSOLE_MODE(0);
+            if BOOL(0) == GetConsoleMode(console_handle, &mut console_mode) {
+                return Err(GetLastError().0);
             }
+
+            // VT processing not already enabled?
+            if console_mode & ENABLE_VIRTUAL_TERMINAL_PROCESSING == CONSOLE_MODE(0) {
+                // https://docs.microsoft.com/en-us/windows/console/setconsolemode
+                if BOOL(0)
+                    == SetConsoleMode(
+                        console_handle,
+                        console_mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING,
+                    )
+                {
+                    return Err(GetLastError().0);
+                }
+            }
+            Ok(())
+        } else {
+            Err(GetLastError().0)
         }
     }
-
-    Ok(())
 }


### PR DESCRIPTION
Closes issue #14

How I tested:
```
cargo test --all-features
cargo fmt
cargo clippy --all-features
```

The clippy warning seems to be unrelated, but I've also fixed it since it fails the CI

And then run examples
https://www.yogile.com/alxq57uebw6/21t/share/?vsc=e105adfdf

I've added ``nu_ansi_term::enable_ansi_support().unwrap();`` line a first line for the example ``main`` function as it was not called by examples. I am on Win11