### PR TITLE
Use the `windows-sys` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,8 @@ derive_serde_style = ["serde"]
 serde = { version="1.0.90", features=["derive"], optional=true }
 
 [target.'cfg(windows)'.dependencies.windows]
-version = "0.44"
+version = "0.45.0"
+package = "windows-sys"
 features = [
     "Win32_Foundation",
     "Win32_System_Console",

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -11,48 +11,47 @@ pub fn enable_ansi_support() -> Result<(), u32> {
     // ref: https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences#EXAMPLE_OF_ENABLING_VIRTUAL_TERMINAL_PROCESSING @@ https://archive.is/L7wRJ#76%
     use windows::w;
     use windows::Win32::Foundation::GetLastError;
-    use windows::Win32::Foundation::BOOL;
-    use windows::Win32::Storage::FileSystem::FILE_FLAGS_AND_ATTRIBUTES;
+    use windows::Win32::Foundation::INVALID_HANDLE_VALUE;
     use windows::Win32::Storage::FileSystem::{CreateFileW, OPEN_EXISTING};
     use windows::Win32::Storage::FileSystem::{
         FILE_GENERIC_READ, FILE_GENERIC_WRITE, FILE_SHARE_WRITE,
     };
+    use windows::Win32::System::Console::ENABLE_VIRTUAL_TERMINAL_PROCESSING;
     use windows::Win32::System::Console::{GetConsoleMode, SetConsoleMode};
-    use windows::Win32::System::Console::{CONSOLE_MODE, ENABLE_VIRTUAL_TERMINAL_PROCESSING};
 
     unsafe {
         // ref: https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew
         // Using `CreateFileW("CONOUT$", ...)` to retrieve the console handle works correctly even if STDOUT and/or STDERR are redirected
-        if let Ok(console_handle) = CreateFileW(
+        let console_handle = CreateFileW(
             w!("CONOUT$"),
             FILE_GENERIC_READ | FILE_GENERIC_WRITE,
             FILE_SHARE_WRITE,
-            None,
+            std::ptr::null_mut(), // SECURITY_ATTRIBUTES
             OPEN_EXISTING,
-            FILE_FLAGS_AND_ATTRIBUTES(0),
-            None,
-        ) {
-            // ref: https://docs.microsoft.com/en-us/windows/console/getconsolemode
-            let mut console_mode = CONSOLE_MODE(0);
-            if BOOL(0) == GetConsoleMode(console_handle, &mut console_mode) {
-                return Err(GetLastError().0);
-            }
-
-            // VT processing not already enabled?
-            if console_mode & ENABLE_VIRTUAL_TERMINAL_PROCESSING == CONSOLE_MODE(0) {
-                // https://docs.microsoft.com/en-us/windows/console/setconsolemode
-                if BOOL(0)
-                    == SetConsoleMode(
-                        console_handle,
-                        console_mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING,
-                    )
-                {
-                    return Err(GetLastError().0);
-                }
-            }
-            Ok(())
-        } else {
-            Err(GetLastError().0)
+            0, // FILE_FLAGS_AND_ATTRIBUTES
+            0, // hTemplateFile: HANDLE
+        );
+        if console_handle == INVALID_HANDLE_VALUE {
+            return Err(GetLastError());
         }
+
+        // ref: https://docs.microsoft.com/en-us/windows/console/getconsolemode
+        let mut console_mode = 0;
+        if 0 == GetConsoleMode(console_handle, &mut console_mode) {
+            return Err(GetLastError());
+        }
+
+        // VT processing not already enabled?
+        if console_mode & ENABLE_VIRTUAL_TERMINAL_PROCESSING == 0 {
+            // https://docs.microsoft.com/en-us/windows/console/setconsolemode
+            if 0 == SetConsoleMode(
+                console_handle,
+                console_mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING,
+            ) {
+                return Err(GetLastError());
+            }
+        }
+
+        Ok(())
     }
 }


### PR DESCRIPTION
The `windows-sys` crate is only 2.5MB, compared to 11.5MB for the `windows` crate.