### PR TITLE
Enable ansi support for examples under windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,4 @@ jobs:
       - run: cargo test
       - run: cargo fmt --check --all
       - run: cargo clippy -- -D warnings
+      - run: cargo run --example 256_colors

--- a/examples/256_colors.rs
+++ b/examples/256_colors.rs
@@ -10,6 +10,9 @@ use nu_ansi_term::Color;
 // - 232 to 255 are shades of grey.
 
 fn main() {
+    #[cfg(windows)]
+    nu_ansi_term::enable_ansi_support().unwrap();
+
     // First two lines
     for c in 0..8 {
         glow(c, c != 0);

--- a/examples/basic_colors.rs
+++ b/examples/basic_colors.rs
@@ -4,6 +4,9 @@ use nu_ansi_term::{Color::*, Style};
 // This example prints out the 16 basic colors.
 
 fn main() {
+    #[cfg(windows)]
+    nu_ansi_term::enable_ansi_support().unwrap();
+
     let normal = Style::default();
 
     println!("{} {}", normal.paint("Normal"), normal.bold().paint("bold"));

--- a/examples/gradient_colors.rs
+++ b/examples/gradient_colors.rs
@@ -1,6 +1,9 @@
 use nu_ansi_term::{build_all_gradient_text, Color, Gradient, Rgb, TargetGround};
 
 fn main() {
+    #[cfg(windows)]
+    nu_ansi_term::enable_ansi_support().unwrap();
+
     let text = "lorem ipsum quia dolor sit amet, consectetur, adipisci velit";
 
     // a gradient from hex colors

--- a/examples/rgb_colors.rs
+++ b/examples/rgb_colors.rs
@@ -9,6 +9,9 @@ const WIDTH: i32 = 80;
 const HEIGHT: i32 = 24;
 
 fn main() {
+    #[cfg(windows)]
+    nu_ansi_term::enable_ansi_support().unwrap();
+
     for row in 0..HEIGHT {
         for col in 0..WIDTH {
             let r = (row * 255 / HEIGHT) as u8;


### PR DESCRIPTION
GitHub Actions log supports ansi colors. Let's show them off.

![image](https://user-images.githubusercontent.com/2128532/223199022-d3b77965-8593-4509-bc06-4e2f594f2381.png)
