### PR TITLE
Rust Edition 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ doctest = true
 derive_serde_style = ["serde"]
 
 [dependencies]
-serde = { version="1.0.90", features=["derive"], optional=true }
+serde = { version="1.0.152", features=["derive"], optional=true }
 
 [target.'cfg(windows)'.dependencies.windows]
 version = "0.45.0"
@@ -32,8 +32,8 @@ features = [
 ]
 
 [dev-dependencies]
-doc-comment = "0.3"
-regex = "1.1.9"
+doc-comment = "0.3.3"
+regex = "1.7.1"
 
 [dev-dependencies.serde_json]
-version = "1.0.39"
+version = "1.0.94"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "The Nushell Project Developers",
 ]
 description = "Library for ANSI terminal colors and styles (bold, underline)"
-edition = "2018"
+edition = "2021"
 license = "MIT"
 name = "nu-ansi-term"
 version = "0.46.0"


### PR DESCRIPTION
All other crates from Nushell organization seem to already use this Rust edition. Just update this crate to align the usage of it.