### PR TITLE
Use semver version for dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,10 @@ doctest = true
 derive_serde_style = ["serde"]
 
 [dependencies]
-serde = { version="1.0.152", features=["derive"], optional=true }
+serde = { version="1.0", features=["derive"], optional=true }
 
 [target.'cfg(windows)'.dependencies.windows]
-version = "0.45.0"
+version = "0.45"
 package = "windows-sys"
 features = [
     "Win32_Foundation",
@@ -33,8 +33,8 @@ features = [
 ]
 
 [dev-dependencies]
-doc-comment = "0.3.3"
-regex = "1.7.1"
+doc-comment = "0.3"
+regex = "1.7"
 
 [dev-dependencies.serde_json]
-version = "1.0.94"
+version = "1.0"


### PR DESCRIPTION
I prefer the usage of semver as version constraining for crates. Since they can relax a bit the usage of dependencies in project using this crate.