### PR TITLE
Set MSRV to 1.62.0 in package metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ authors = [
 ]
 description = "Library for ANSI terminal colors and styles (bold, underline)"
 edition = "2021"
+rust-version = "1.62.1"
 license = "MIT"
 name = "nu-ansi-term"
 version = "0.46.0"


### PR DESCRIPTION
clippy respects the rust version set in the package metadata and wouldn't break the build job for newer rust features.

`#[derive(Derive)]` on enums was stabilized with [rust 1.62](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1620-2022-06-30)

- #29 