### PR TITLE
Bump version for `0.47` release.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 rust-version = "1.62.1"
 license = "MIT"
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.47.0"
 repository = "https://github.com/nushell/nu-ansi-term"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This crate works with [Cargo](http://crates.io). Add the following to your `Carg
 
 ```toml
 [dependencies]
-nu-ansi-term = "0.46"
+nu-ansi-term = "0.47"
 ```
 
 ## Basic usage


### PR DESCRIPTION
Will be used starting with `reedline` 0.17 and `nu` 0.77.
