### PR TITLE
Unit tests update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,4 @@ features = [
 
 [dev-dependencies]
 doc-comment = "0.3.3"
-
-[dev-dependencies.serde_json]
-version = "1.0.94"
+serde_json = "1.0.94"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ features = [
 
 [dev-dependencies]
 doc-comment = "0.3.3"
-regex = "1.7.1"
 
 [dev-dependencies.serde_json]
 version = "1.0.94"

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -93,10 +93,6 @@ mod test {
     use crate::style::Color::*;
     use crate::style::Style;
 
-    fn style() -> Style {
-        Style::new()
-    }
-
     macro_rules! test {
         ($name: ident: $obj: expr => $result: expr) => {
             #[test]
@@ -106,10 +102,10 @@ mod test {
         };
     }
 
-    test!(empty:   style()                  => "Style {}");
-    test!(bold:    style().bold()           => "Style { bold }");
-    test!(italic:  style().italic()         => "Style { italic }");
-    test!(both:    style().bold().italic()  => "Style { bold, italic }");
+    test!(empty:   Style::new()                  => "Style {}");
+    test!(bold:    Style::new().bold()           => "Style { bold }");
+    test!(italic:  Style::new().italic()         => "Style { italic }");
+    test!(both:    Style::new().bold().italic()  => "Style { bold, italic }");
 
     test!(red:     Red.normal()                     => "Style { fg(Red) }");
     test!(redblue: Red.normal().on(Rgb(3, 2, 4))    => "Style { fg(Red), on(Rgb(3, 2, 4)) }");

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -121,23 +121,20 @@ mod test {
     #[test]
     fn long_and_detailed() {
         let expected_debug = "Style { fg(Blue), bold }";
-        let expected_pretty_repat = r##"(?x)
-        Style\s+\{\s+
-            foreground:\s+Some\(\s+
-                Blue,?\s+
-            \),\s+
-            background:\s+None,\s+
-            blink:\s+false,\s+
-            bold:\s+true,\s+
-            dimmed:\s+false,\s+
-            hidden:\s+false,\s+
-            italic:\s+false,\s+
-            reverse:\s+false,\s+
-            strikethrough:\s+
-            false,\s+
-            underline:\s+false,?\s+
-            \}"##;
-        let re = regex::Regex::new(expected_pretty_repat).unwrap();
+        let expected_pretty_repat = r"Style {
+    foreground: Some(
+        Blue,
+    ),
+    background: None,
+    blink: false,
+    bold: true,
+    dimmed: false,
+    hidden: false,
+    italic: false,
+    reverse: false,
+    strikethrough: false,
+    underline: false,
+}";
 
         let style = Blue.bold();
         let style_fmt_debug = format!("{:?}", style);
@@ -146,6 +143,6 @@ mod test {
         println!("style_fmt_pretty:\n{}", style_fmt_pretty);
 
         assert_eq!(expected_debug, style_fmt_debug);
-        assert!(re.is_match(&style_fmt_pretty));
+        assert_eq!(expected_pretty_repat, style_fmt_pretty);
     }
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -594,7 +594,7 @@ mod serde_json_tests {
 
         assert_eq!(
             serde_json::to_string(&colors).unwrap(),
-            String::from("[\"Red\",\"Blue\",{\"Rgb\":[123,123,123]},{\"Fixed\":255}]")
+            "[\"Red\",\"Blue\",{\"Rgb\":[123,123,123]},{\"Fixed\":255}]"
         );
     }
 


### PR DESCRIPTION
Just a quick work on unit tests. I removed the crate `regex`, since we only used 1% of what we can achieve through a regex, and IMO, we can simply do it without this dependency.

This MR should be looked commit per commit.