### PR TITLE
Quick fix around doc tests regarding Color::prefix().

### DIFF
--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -259,8 +259,8 @@ impl Color {
     /// ```
     /// use nu_ansi_term::Color::Green;
     ///
-    /// assert_eq!("\x1b[0m",
-    ///            Green.suffix().to_string());
+    /// assert_eq!("\x1b[32m",
+    ///            Green.prefix().to_string());
     /// ```
     pub fn prefix(self) -> Prefix {
         Prefix(self.normal())


### PR DESCRIPTION
A really quick MR to fix a bad doc test.