### PR TITLE
Use new doc include_str macro to properly test the README.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,5 +33,4 @@ features = [
 ]
 
 [dev-dependencies]
-doc-comment = "0.3.3"
 serde_json = "1.0.94"

--- a/README.md
+++ b/README.md
@@ -120,9 +120,9 @@ There’s nothing stopping you from using these as `Fixed` colors instead, but t
 You can also access full 24-bit color by using the `Color::RGB` variant, which takes separate `u8` arguments for red, green, and blue:
 
 ```rust
-use nu_ansi_term::Color::RGB;
+use nu_ansi_term::Color::Rgb;
 
-RGB(70, 130, 180).paint("Steel blue");
+Rgb(70, 130, 180).paint("Steel blue");
 ```
 
 ## Combining successive colored strings

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,12 +232,11 @@
 #![crate_name = "nu_ansi_term"]
 #![crate_type = "rlib"]
 #![warn(missing_copy_implementations)]
-// #![warn(missing_docs)]
 #![warn(trivial_casts, trivial_numeric_casts)]
-// #![warn(unused_extern_crates, unused_qualifications)]
 
-#[cfg(test)]
-doc_comment::doctest!("../README.md");
+#[cfg(doctest)]
+#[doc = include_str!("../README.md")]
+pub struct ReadmeTests;
 
 pub mod ansi;
 pub use ansi::{Infix, Prefix, Suffix};

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -67,34 +67,6 @@ impl Rgb {
         Self::from_f32(x, x, x)
     }
 
-    /// Creates a new [Rgb] color from a [HSL] color
-    // pub fn from_hsl(hsl: HSL) -> Self {
-    //     if hsl.s == 0.0 {
-    //         return Self::gray_f32(hsl.l);
-    //     }
-
-    //     let q = if hsl.l < 0.5 {
-    //         hsl.l * (1.0 + hsl.s)
-    //     } else {
-    //         hsl.l + hsl.s - hsl.l * hsl.s
-    //     };
-    //     let p = 2.0 * hsl.l - q;
-    //     let h2c = |t: f32| {
-    //         let t = t.clamp(0.0, 1.0);
-    //         if 6.0 * t < 1.0 {
-    //             p + 6.0 * (q - p) * t
-    //         } else if t < 0.5 {
-    //             q
-    //         } else if 1.0 < 1.5 * t {
-    //             p + 6.0 * (q - p) * (1.0 / 1.5 - t)
-    //         } else {
-    //             p
-    //         }
-    //     };
-
-    //     Self::from_f32(h2c(hsl.h + 1.0 / 3.0), h2c(hsl.h), h2c(hsl.h - 1.0 / 3.0))
-    // }
-
     /// Computes the linear interpolation between `self` and `other` for `t`
     pub fn lerp(&self, other: Self, t: f32) -> Self {
         let t = t.clamp(0.0, 1.0);


### PR DESCRIPTION
Remove unused warnings and implementation of `from_hsl` which reference a `HSL` structure that does not more exist