### PR TITLE
Add feature: gnu_legacy mode for ansi styles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
           components: rustfmt, clippy
 
       - run: cargo build --all-features
+      - run: cargo test
       - run: cargo test --all-features
       - run: cargo fmt --check --all
       - run: cargo clippy -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ doctest = true
 
 [features]
 derive_serde_style = ["serde"]
+gnu_legacy = []
 
 [dependencies]
 serde = { version="1.0.152", features=["derive"], optional=true }

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ This crate works with [Cargo](http://crates.io). Add the following to your `Carg
 ```toml
 [dependencies]
 nu-ansi-term = "0.47"
+
+# optional gnu-legacy mode to have two digit instead of one digit styles
+nu-ansi-term = { version="0.47", features=["gnu_legacy"] }
 ```
 
 ## Basic usage

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -24,6 +24,8 @@ impl Style {
                     write!(f, ";")?;
                 }
                 written_anything = true;
+                #[cfg(feature = "gnu_legacy")]
+                write!(f, "0")?;
                 write!(f, "{}", c)?;
                 Ok(())
             };
@@ -337,22 +339,24 @@ impl fmt::Display for Suffix {
 }
 
 #[cfg(test)]
+macro_rules! test {
+    ($name: ident: $style: expr; $input: expr => $result: expr) => {
+        #[test]
+        fn $name() {
+            assert_eq!($style.paint($input).to_string(), $result.to_string());
+
+            let mut v = Vec::new();
+            $style.paint($input.as_bytes()).write_to(&mut v).unwrap();
+            assert_eq!(v.as_slice(), $result.as_bytes());
+        }
+    };
+}
+
+#[cfg(test)]
+#[cfg(not(feature = "gnu_legacy"))]
 mod test {
     use crate::style::Color::*;
     use crate::style::Style;
-
-    macro_rules! test {
-        ($name: ident: $style: expr; $input: expr => $result: expr) => {
-            #[test]
-            fn $name() {
-                assert_eq!($style.paint($input).to_string(), $result.to_string());
-
-                let mut v = Vec::new();
-                $style.paint($input.as_bytes()).write_to(&mut v).unwrap();
-                assert_eq!(v.as_slice(), $result.as_bytes());
-            }
-        };
-    }
 
     test!(plain:                 Style::default();                  "text/plain" => "text/plain");
     test!(red:                   Red;                               "hi" => "\x1B[31mhi\x1B[0m");
@@ -404,4 +408,47 @@ mod test {
         assert_eq!(White.normal().infix(Blue.normal()).to_string(), "\x1B[34m");
         assert_eq!(Blue.bold().infix(Blue.bold()).to_string(), "");
     }
+}
+
+#[cfg(test)]
+#[cfg(feature = "gnu_legacy")]
+mod gnu_legacy_test {
+    use crate::style::Color::*;
+    use crate::style::Style;
+
+    test!(plain:                 Style::default();                  "text/plain" => "text/plain");
+    test!(red:                   Red;                               "hi" => "\x1B[31mhi\x1B[0m");
+    test!(black:                 Black.normal();                    "hi" => "\x1B[30mhi\x1B[0m");
+    test!(yellow_bold:           Yellow.bold();                     "hi" => "\x1B[01;33mhi\x1B[0m");
+    test!(yellow_bold_2:         Yellow.normal().bold();            "hi" => "\x1B[01;33mhi\x1B[0m");
+    test!(blue_underline:        Blue.underline();                  "hi" => "\x1B[04;34mhi\x1B[0m");
+    test!(green_bold_ul:         Green.bold().underline();          "hi" => "\x1B[01;04;32mhi\x1B[0m");
+    test!(green_bold_ul_2:       Green.underline().bold();          "hi" => "\x1B[01;04;32mhi\x1B[0m");
+    test!(purple_on_white:       Purple.on(White);                  "hi" => "\x1B[47;35mhi\x1B[0m");
+    test!(purple_on_white_2:     Purple.normal().on(White);         "hi" => "\x1B[47;35mhi\x1B[0m");
+    test!(yellow_on_blue:        Style::new().on(Blue).fg(Yellow);  "hi" => "\x1B[44;33mhi\x1B[0m");
+    test!(magenta_on_white:      Magenta.on(White);                  "hi" => "\x1B[47;35mhi\x1B[0m");
+    test!(magenta_on_white_2:    Magenta.normal().on(White);         "hi" => "\x1B[47;35mhi\x1B[0m");
+    test!(yellow_on_blue_2:      Cyan.on(Blue).fg(Yellow);          "hi" => "\x1B[44;33mhi\x1B[0m");
+    test!(cyan_bold_on_white:    Cyan.bold().on(White);             "hi" => "\x1B[01;47;36mhi\x1B[0m");
+    test!(cyan_ul_on_white:      Cyan.underline().on(White);        "hi" => "\x1B[04;47;36mhi\x1B[0m");
+    test!(cyan_bold_ul_on_white: Cyan.bold().underline().on(White); "hi" => "\x1B[01;04;47;36mhi\x1B[0m");
+    test!(cyan_ul_bold_on_white: Cyan.underline().bold().on(White); "hi" => "\x1B[01;04;47;36mhi\x1B[0m");
+    test!(fixed:                 Fixed(100);                        "hi" => "\x1B[38;5;100mhi\x1B[0m");
+    test!(fixed_on_purple:       Fixed(100).on(Purple);             "hi" => "\x1B[45;38;5;100mhi\x1B[0m");
+    test!(fixed_on_fixed:        Fixed(100).on(Fixed(200));         "hi" => "\x1B[48;5;200;38;5;100mhi\x1B[0m");
+    test!(rgb:                   Rgb(70,130,180);                   "hi" => "\x1B[38;2;70;130;180mhi\x1B[0m");
+    test!(rgb_on_blue:           Rgb(70,130,180).on(Blue);          "hi" => "\x1B[44;38;2;70;130;180mhi\x1B[0m");
+    test!(blue_on_rgb:           Blue.on(Rgb(70,130,180));          "hi" => "\x1B[48;2;70;130;180;34mhi\x1B[0m");
+    test!(rgb_on_rgb:            Rgb(70,130,180).on(Rgb(5,10,15));  "hi" => "\x1B[48;2;5;10;15;38;2;70;130;180mhi\x1B[0m");
+    test!(bold:                  Style::new().bold();               "hi" => "\x1B[01mhi\x1B[0m");
+    test!(underline:             Style::new().underline();          "hi" => "\x1B[04mhi\x1B[0m");
+    test!(bunderline:            Style::new().bold().underline();   "hi" => "\x1B[01;04mhi\x1B[0m");
+    test!(dimmed:                Style::new().dimmed();             "hi" => "\x1B[02mhi\x1B[0m");
+    test!(italic:                Style::new().italic();             "hi" => "\x1B[03mhi\x1B[0m");
+    test!(blink:                 Style::new().blink();              "hi" => "\x1B[05mhi\x1B[0m");
+    test!(reverse:               Style::new().reverse();            "hi" => "\x1B[07mhi\x1B[0m");
+    test!(hidden:                Style::new().hidden();             "hi" => "\x1B[08mhi\x1B[0m");
+    test!(stricken:              Style::new().strikethrough();      "hi" => "\x1B[09mhi\x1B[0m");
+    test!(lr_on_lr:              LightRed.on(LightRed);             "hi" => "\x1B[101;91mhi\x1B[0m");
 }


### PR DESCRIPTION
Hi,
gnu coreutils are still using double digit styles instead of single digit styles. 
To make this available in uucoreutils (the rust drop in replacement for gnu core utils) I added a feature called gnu_legacy. 
[Related PR](https://github.com/uutils/coreutils/pull/4867)

By turning it on it will generate styles double digit. If not turned on it will behave as before. Tests have been added.
```rust
// without feature flag gnu_legacy
    test!(bunderline:            Style::new().bold().underline();   "hi" => ,"\x1B[1;4mhi\x1B[0m");
// with feature flag gnu_legacy
    test!(bunderline:            Style::new().bold().underline();   "hi" => "\x1B[01;04mhi\x1B[0m");
```
Please see the code and I hope this feature can make it.

The second missing feature would be to have the option to reset a style before applying. I would open another PR for this.