### PR TITLE
Add resetted styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,18 @@ Red.normal().paint("yet another red string");
 Style::default().paint("a completely regular string");
 ```
 
+Sometimes it is desirable to hard-reset a style/color just before
+applying a new one. To reset and apply, the `reset_before_style` method can
+be used on either `Color` or `Style` structs.
+
+```rust
+use nu_ansi_term::Style;
+
+println!("\x1b[33mHow about some {} \x1b[33mand {}?\x1b[0m",
+         Style::new().reset_before_style().bold().paint("bold"),
+         Style::new().reset_before_style().underline().paint("underline"));
+```
+
 ## Extended colors
 
 You can access the extended range of 256 colors by using the `Color::Fixed` variant, which takes an argument of the color number to use.

--- a/examples/basic_colors.rs
+++ b/examples/basic_colors.rs
@@ -17,11 +17,18 @@ fn main() {
     println!("{} {}", Purple.paint("Purple"), Purple.bold().paint("bold"));
     println!("{} {}", Cyan.paint("Cyan"), Cyan.bold().paint("bold"));
     println!("{} {}", White.paint("White"), White.bold().paint("bold"));
-    println!("\nReset before style at work:");
-    println!("\x1b[33mReset {} \x1b[33mand {}\x1b[0m",
-         Style::new().reset_before_style().bold().paint("bold"),
-         Style::new().reset_before_style().underline().paint("underline"));
-    println!("\x1b[33mDo not reset {} \x1b[33mand {}\x1b[0m",
-         Style::new().bold().paint("bold"),
-         Style::new().underline().paint("underline"));
+    println!("\nreset_before_style at work:");
+    println!(
+        "\x1b[33mReset {} \x1b[33mand {}\x1b[0m",
+        Style::new().reset_before_style().bold().paint("bold"),
+        Style::new()
+            .reset_before_style()
+            .underline()
+            .paint("underline")
+    );
+    println!(
+        "\x1b[33mDo not reset {} \x1b[33mand {}\x1b[0m",
+        Style::new().bold().paint("bold"),
+        Style::new().underline().paint("underline")
+    );
 }

--- a/examples/basic_colors.rs
+++ b/examples/basic_colors.rs
@@ -17,4 +17,11 @@ fn main() {
     println!("{} {}", Purple.paint("Purple"), Purple.bold().paint("bold"));
     println!("{} {}", Cyan.paint("Cyan"), Cyan.bold().paint("bold"));
     println!("{} {}", White.paint("White"), White.bold().paint("bold"));
+    println!("\nReset before style at work:");
+    println!("\x1b[33mReset {} \x1b[33mand {}\x1b[0m",
+         Style::new().reset_before_style().bold().paint("bold"),
+         Style::new().reset_before_style().underline().paint("underline"));
+    println!("\x1b[33mDo not reset {} \x1b[33mand {}\x1b[0m",
+         Style::new().bold().paint("bold"),
+         Style::new().underline().paint("underline"));
 }

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -346,18 +346,18 @@ mod test {
     use crate::style::Color::*;
     use crate::style::Style;
 
-macro_rules! test {
-    ($name: ident: $style: expr; $input: expr => $result: expr) => {
-        #[test]
-        fn $name() {
-            assert_eq!($style.paint($input).to_string(), $result.to_string());
+    macro_rules! test {
+        ($name: ident: $style: expr; $input: expr => $result: expr) => {
+            #[test]
+            fn $name() {
+                assert_eq!($style.paint($input).to_string(), $result.to_string());
 
-            let mut v = Vec::new();
-            $style.paint($input.as_bytes()).write_to(&mut v).unwrap();
-            assert_eq!(v.as_slice(), $result.as_bytes());
-        }
-    };
-}
+                let mut v = Vec::new();
+                $style.paint($input.as_bytes()).write_to(&mut v).unwrap();
+                assert_eq!(v.as_slice(), $result.as_bytes());
+            }
+        };
+    }
 
     test!(plain:                 Style::default();                  "text/plain" => "text/plain");
     test!(red:                   Red;                               "hi" => "\x1B[31mhi\x1B[0m");

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -412,8 +412,8 @@ mod test {
     test!(magenta_on_white:      Magenta.on(White);                  "hi" => "\x1B[47;35mhi\x1B[0m");
     test!(magenta_on_white_2:    Magenta.normal().on(White);         "hi" => "\x1B[47;35mhi\x1B[0m");
     test!(yellow_on_blue_2:      Cyan.on(Blue).fg(Yellow);          "hi" => "\x1B[44;33mhi\x1B[0m");
-    test!(yellow_on_blue_reset:  Cyan.on(Blue).resetted().fg(Yellow); "hi" => "\x1B[0m\x1B[44;33mhi\x1B[0m");
-    test!(yellow_on_blue_reset_2: Cyan.on(Blue).fg(Yellow).resetted(); "hi" => "\x1B[0m\x1B[44;33mhi\x1B[0m");
+    test!(yellow_on_blue_reset:  Cyan.on(Blue).reset_before_style().fg(Yellow); "hi" => "\x1B[0m\x1B[44;33mhi\x1B[0m");
+    test!(yellow_on_blue_reset_2: Cyan.on(Blue).fg(Yellow).reset_before_style(); "hi" => "\x1B[0m\x1B[44;33mhi\x1B[0m");
     test!(cyan_bold_on_white:    Cyan.bold().on(White);             "hi" => "\x1B[1;47;36mhi\x1B[0m");
     test!(cyan_ul_on_white:      Cyan.underline().on(White);        "hi" => "\x1B[4;47;36mhi\x1B[0m");
     test!(cyan_bold_ul_on_white: Cyan.bold().underline().on(White); "hi" => "\x1B[1;4;47;36mhi\x1B[0m");
@@ -426,8 +426,8 @@ mod test {
     test!(blue_on_rgb:           Blue.on(Rgb(70,130,180));          "hi" => "\x1B[48;2;70;130;180;34mhi\x1B[0m");
     test!(rgb_on_rgb:            Rgb(70,130,180).on(Rgb(5,10,15));  "hi" => "\x1B[48;2;5;10;15;38;2;70;130;180mhi\x1B[0m");
     test!(bold:                  Style::new().bold();               "hi" => "\x1B[1mhi\x1B[0m");
-    test!(bold_with_reset:       Style::new().resetted().bold();    "hi" => "\x1B[0m\x1B[1mhi\x1B[0m");
-    test!(bold_with_reset_2:     Style::new().bold().resetted();    "hi" => "\x1B[0m\x1B[1mhi\x1B[0m");
+    test!(bold_with_reset:       Style::new().reset_before_style().bold(); "hi" => "\x1B[0m\x1B[1mhi\x1B[0m");
+    test!(bold_with_reset_2:     Style::new().bold().reset_before_style(); "hi" => "\x1B[0m\x1B[1mhi\x1B[0m");
     test!(underline:             Style::new().underline();          "hi" => "\x1B[4mhi\x1B[0m");
     test!(bunderline:            Style::new().bold().underline();   "hi" => "\x1B[1;4mhi\x1B[0m");
     test!(dimmed:                Style::new().dimmed();             "hi" => "\x1B[2mhi\x1B[0m");
@@ -471,6 +471,8 @@ mod gnu_legacy_test {
     test!(purple_on_white:       Purple.on(White);                  "hi" => "\x1B[47;35mhi\x1B[0m");
     test!(purple_on_white_2:     Purple.normal().on(White);         "hi" => "\x1B[47;35mhi\x1B[0m");
     test!(yellow_on_blue:        Style::new().on(Blue).fg(Yellow);  "hi" => "\x1B[44;33mhi\x1B[0m");
+    test!(yellow_on_blue_reset:  Cyan.on(Blue).reset_before_style().fg(Yellow); "hi" => "\x1B[0m\x1B[44;33mhi\x1B[0m");
+    test!(yellow_on_blue_reset_2: Cyan.on(Blue).fg(Yellow).reset_before_style(); "hi" => "\x1B[0m\x1B[44;33mhi\x1B[0m");
     test!(magenta_on_white:      Magenta.on(White);                  "hi" => "\x1B[47;35mhi\x1B[0m");
     test!(magenta_on_white_2:    Magenta.normal().on(White);         "hi" => "\x1B[47;35mhi\x1B[0m");
     test!(yellow_on_blue_2:      Cyan.on(Blue).fg(Yellow);          "hi" => "\x1B[44;33mhi\x1B[0m");
@@ -486,6 +488,8 @@ mod gnu_legacy_test {
     test!(blue_on_rgb:           Blue.on(Rgb(70,130,180));          "hi" => "\x1B[48;2;70;130;180;34mhi\x1B[0m");
     test!(rgb_on_rgb:            Rgb(70,130,180).on(Rgb(5,10,15));  "hi" => "\x1B[48;2;5;10;15;38;2;70;130;180mhi\x1B[0m");
     test!(bold:                  Style::new().bold();               "hi" => "\x1B[01mhi\x1B[0m");
+    test!(bold_with_reset:       Style::new().reset_before_style().bold(); "hi" => "\x1B[0m\x1B[01mhi\x1B[0m");
+    test!(bold_with_reset_2:     Style::new().bold().reset_before_style(); "hi" => "\x1B[0m\x1B[01mhi\x1B[0m");
     test!(underline:             Style::new().underline();          "hi" => "\x1B[04mhi\x1B[0m");
     test!(bunderline:            Style::new().bold().underline();   "hi" => "\x1B[01;04mhi\x1B[0m");
     test!(dimmed:                Style::new().dimmed();             "hi" => "\x1B[02mhi\x1B[0m");

--- a/src/style.rs
+++ b/src/style.rs
@@ -81,7 +81,6 @@ impl Style {
         }
     }
 
-
     /// Returns a `Style` with the bold property set.
     ///
     /// # Examples

--- a/src/style.rs
+++ b/src/style.rs
@@ -64,17 +64,17 @@ impl Style {
         Style::default()
     }
 
-    /// Returns a `Style` with the resetted property set.
+    /// Returns a `Style` with the reset_before_style property set.
     ///
     /// # Examples
     ///
     /// ```
     /// use nu_ansi_term::Style;
     ///
-    /// let style = Style::new().resetted();
+    /// let style = Style::new().reset_before_style();
     /// println!("{}", style.paint("hey"));
     /// ```
-    pub const fn resetted(&self) -> Style {
+    pub const fn reset_before_style(&self) -> Style {
         Style {
             with_reset: true,
             ..*self
@@ -571,10 +571,10 @@ impl Color {
     /// ```
     /// use nu_ansi_term::Color;
     ///
-    /// let style = Color::Fixed(244).resetted();
+    /// let style = Color::Fixed(244).reset_before_style();
     /// println!("{}", style.paint("yo"));
     /// ```
-    pub fn resetted(self) -> Style {
+    pub fn reset_before_style(self) -> Style {
         Style {
             foreground: Some(self),
             with_reset: true,

--- a/src/style.rs
+++ b/src/style.rs
@@ -44,6 +44,9 @@ pub struct Style {
 
     /// Whether this style is struckthrough.
     pub is_strikethrough: bool,
+
+    /// Wether this style starts with reset code
+    pub with_reset: bool,
 }
 
 impl Style {
@@ -60,6 +63,24 @@ impl Style {
     pub fn new() -> Style {
         Style::default()
     }
+
+    /// Returns a `Style` with the resetted property set.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use nu_ansi_term::Style;
+    ///
+    /// let style = Style::new().resetted();
+    /// println!("{}", style.paint("hey"));
+    /// ```
+    pub const fn resetted(&self) -> Style {
+        Style {
+            with_reset: true,
+            ..*self
+        }
+    }
+
 
     /// Returns a `Style` with the bold property set.
     ///
@@ -269,6 +290,7 @@ impl Default for Style {
             is_reverse: false,
             is_hidden: false,
             is_strikethrough: false,
+            with_reset: false,
         }
     }
 }
@@ -542,6 +564,25 @@ impl Color {
         }
     }
 
+    /// Returns a `Style` thats resets all styling before applying
+    /// the foreground color set to this color.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use nu_ansi_term::Color;
+    ///
+    /// let style = Color::Fixed(244).resetted();
+    /// println!("{}", style.paint("yo"));
+    /// ```
+    pub fn resetted(self) -> Style {
+        Style {
+            foreground: Some(self),
+            with_reset: true,
+            ..Style::default()
+        }
+    }
+
     /// Returns a `Style` with the foreground color set to this color and the
     /// background color property set to the given color.
     ///
@@ -619,6 +660,6 @@ mod serde_json_tests {
     fn style_serialization() {
         let style = Style::default();
 
-        assert_eq!(serde_json::to_string(&style).unwrap(), "{\"foreground\":null,\"background\":null,\"is_bold\":false,\"is_dimmed\":false,\"is_italic\":false,\"is_underline\":false,\"is_blink\":false,\"is_reverse\":false,\"is_hidden\":false,\"is_strikethrough\":false}".to_string());
+        assert_eq!(serde_json::to_string(&style).unwrap(), "{\"foreground\":null,\"background\":null,\"is_bold\":false,\"is_dimmed\":false,\"is_italic\":false,\"is_underline\":false,\"is_blink\":false,\"is_reverse\":false,\"is_hidden\":false,\"is_strikethrough\":false,\"with_reset\":false}".to_string());
     }
 }


### PR DESCRIPTION
Hi,
gnu coreutils are are in parts resetting styles everytime they are applied. 
To make this available in uucoreutils (the rust drop in replacement for gnu core utils) I added a chainable style called "resetted" which will print the reset style before the actual string. 

[Related PR](https://github.com/uutils/coreutils/pull/4867)
```rust
    test!(bold:                  Style::new().bold();               "hi" => "\x1B[1mhi\x1B[0m");
    test!(bold_with_reset:       Style::new().resetted().bold();    "hi" => "\x1B[0m\x1B[1mhi\x1B[0m");
    test!(bold_with_reset_2:     Style::new().bold().resetted();    "hi" => "\x1B[0m\x1B[1mhi\x1B[0m");
```
Please see the code and I hope this feature can make it.