### PR TITLE
Add support for hyperlinks and other OSC codes

### DIFF
--- a/src/difference.rs
+++ b/src/difference.rs
@@ -43,6 +43,10 @@ impl Difference {
             return Empty;
         }
 
+        if first.has_sgr() && !next.has_sgr() {
+            return Reset;
+        }
+
         // Cannot un-bold, so must Reset.
         if first.is_bold && !next.is_bold {
             return Reset;
@@ -87,6 +91,10 @@ impl Difference {
             return Reset;
         }
 
+        if first.oscontrol.is_some() && next.oscontrol.is_none() {
+            return Reset;
+        }
+
         let mut extra_styles = Style::default();
 
         if first.is_bold != next.is_bold {
@@ -127,6 +135,10 @@ impl Difference {
 
         if first.background != next.background {
             extra_styles.background = next.background;
+        }
+
+        if first.oscontrol != next.oscontrol {
+            extra_styles.oscontrol = next.oscontrol;
         }
 
         ExtraStyles(extra_styles)

--- a/src/style.rs
+++ b/src/style.rs
@@ -21,6 +21,12 @@ pub struct Style {
     /// The style's background color, if it has one.
     pub background: Option<Color>,
 
+    // The style's os control type, if it has one.
+    // Used by corresponding public API functions in
+    // AnsiGenericString. This allows us to keep the
+    // prefix and suffix bits in the Style definition.
+    pub(crate) oscontrol: Option<OSControl>,
+
     /// Whether this style is bold.
     pub is_bold: bool,
 
@@ -250,6 +256,32 @@ impl Style {
         }
     }
 
+    pub(crate) fn hyperlink(&mut self) -> &mut Style {
+        self.oscontrol = Some(OSControl::Hyperlink);
+        self
+    }
+
+    pub(crate) fn title() -> Style {
+        Self {
+            oscontrol: Some(OSControl::Title),
+            ..Default::default()
+        }
+    }
+
+    pub(crate) fn icon() -> Style {
+        Self {
+            oscontrol: Some(OSControl::Icon),
+            ..Default::default()
+        }
+    }
+
+    pub(crate) fn cwd() -> Style {
+        Self {
+            oscontrol: Some(OSControl::Cwd),
+            ..Default::default()
+        }
+    }
+
     /// Return true if this `Style` has no actual styles, and can be written
     /// without any control characters.
     ///
@@ -263,6 +295,21 @@ impl Style {
     /// ```
     pub fn is_plain(self) -> bool {
         self == Style::default()
+    }
+
+    #[inline]
+    pub(crate) fn has_sgr(self) -> bool {
+        self.foreground.is_some()
+            || self.background.is_some()
+            || self.is_bold
+            || self.is_dimmed
+            || self.is_italic
+            || self.is_underline
+            || self.is_blink
+            || self.is_reverse
+            || self.is_hidden
+            || self.is_strikethrough
+            || self.with_reset
     }
 }
 
@@ -281,6 +328,7 @@ impl Default for Style {
         Style {
             foreground: None,
             background: None,
+            oscontrol: None,
             is_bold: false,
             is_dimmed: false,
             is_italic: false,
@@ -618,6 +666,21 @@ impl From<Color> for Style {
     }
 }
 
+#[non_exhaustive]
+#[derive(Eq, PartialEq, Clone, Copy)]
+#[cfg_attr(
+    feature = "derive_serde_style",
+    derive(serde::Deserialize, serde::Serialize)
+)]
+pub(crate) enum OSControl {
+    Hyperlink,
+    Title,
+    Icon,
+    Cwd,
+    //ScrollMarkerPromptBegin, // \e[?7711l
+    //ScrollMarkerPromptEnd, // \e[?7711h
+}
+
 #[cfg(test)]
 #[cfg(feature = "derive_serde_style")]
 mod serde_json_tests {
@@ -659,6 +722,6 @@ mod serde_json_tests {
     fn style_serialization() {
         let style = Style::default();
 
-        assert_eq!(serde_json::to_string(&style).unwrap(), "{\"foreground\":null,\"background\":null,\"is_bold\":false,\"is_dimmed\":false,\"is_italic\":false,\"is_underline\":false,\"is_blink\":false,\"is_reverse\":false,\"is_hidden\":false,\"is_strikethrough\":false,\"with_reset\":false}".to_string());
+        assert_eq!(serde_json::to_string(&style).unwrap(), "{\"foreground\":null,\"background\":null,\"oscontrol\":null,\"is_bold\":false,\"is_dimmed\":false,\"is_italic\":false,\"is_underline\":false,\"is_blink\":false,\"is_reverse\":false,\"is_hidden\":false,\"is_strikethrough\":false,\"with_reset\":false}".to_string());
     }
 }


### PR DESCRIPTION
Add support for producing colorized/stylized hyperlinks, among a selection of other OS Control (OSC) codes such as setting the window title, application/window icon, and notifying the terminal about the  current working directory. The main goal is to satisfy #6 while also supporting a few other very common OSC codes.

There has already been some discussion and a change proposed for handling hyperlinks in the dormant rust-ansi-term repo: (See: https://github.com/ogham/rust-ansi-term/pull/61) The above proposed change breaks the Copy trait for Style and would require changing downstream projects that rely on it.

These features aren't really about styling text so much as adding more information for the terminal emulator to present to the user either outside of the typical area for rendered terminal output or somewhat out-of-band with it.

So this change takes a different approach than taken in the referenced pull request.

An enum describing the supported OSC codes, which is not exposed outside the crate, is used to indicate that a Style has additional terminal prefix and suffix output control codes to take care of for hyperlinks, titles, etc. These let us keep the prefix/suffix handling consistent.

However rather than library users using these enums directly or calling externally visible functions on Style or Color struct, AnsiGenericString uses them to implement its hyperlink(), title(), etc. functions. These store the hyperlink "src" string, title, etc. within the
AnsiGenericString rather than in the Style.

Style remains Copy-able, and, since it already stores strings, AnsiGenericString traits are consistent with this choice. The locations of the functions better reflect what's happening because the supplied strings are not meant to be rendered inline with the ANSI-styled output.

The OSControl enum also nicely describes the subset of OSC codes the package currently supports.