### PR TITLE
Revert removal of the patch versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,10 @@ derive_serde_style = ["serde"]
 gnu_legacy = []
 
 [dependencies]
-serde = { version="1.0", features=["derive"], optional=true }
+serde = { version="1.0.152", features=["derive"], optional=true }
 
 [target.'cfg(windows)'.dependencies.windows]
-version = "0.48"
+version = "0.48.0"
 package = "windows-sys"
 features = [
     "Win32_Foundation",
@@ -34,5 +34,5 @@ features = [
 ]
 
 [dev-dependencies]
-doc-comment = "0.3"
-serde_json = "1.0"
+doc-comment = "0.3.3"
+serde_json = "1.0.94"


### PR DESCRIPTION
This readds the patch versions in the cargo version specifiers to ensure
that we include a tested working version. In theory the could have been
breakage with one of the included patch versions of crates we depend on
so it is best practice to supply a full version specifier. Cargo will
automatically pull in a higher version when running `cargo update` or
building this library with another crate that requires a higher version.

See https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-dependencies-from-cratesio

This reverts commit 313eac446c27b30dc12013692d770d37cd38522f.
