### PR TITLE
Bump version for 0.48.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 rust-version = "1.62.1"
 license = "MIT"
 name = "nu-ansi-term"
-version = "0.47.0"
+version = "0.48.0"
 repository = "https://github.com/nushell/nu-ansi-term"
 
 [lib]


### PR DESCRIPTION
Includes addition of OSC sequence support and support for outputting
codes in a GNU-style legacy mode that includes leading zeros for several
CSI sequences.
