### PR TITLE
Use chaining for `AnsiGenericString::hyperlink`

### DIFF
--- a/examples/hyperlink.rs
+++ b/examples/hyperlink.rs
@@ -7,8 +7,10 @@ fn main() {
     nu_ansi_term::enable_ansi_support().unwrap();
 
     let sleep_ms = parse_cmd_args();
-    let mut link = Color::Blue.underline().paint("Link to example.com");
-    link.hyperlink("https://example.com");
+    let link = Color::Blue
+        .underline()
+        .paint("Link to example.com")
+        .hyperlink("https://example.com");
 
     println!("{}", link);
     sleep(sleep_ms);

--- a/src/display.rs
+++ b/src/display.rs
@@ -182,17 +182,17 @@ where
     /// ```
     /// use nu_ansi_term::Color::Red;
     ///
-    /// let mut link_string = Red.paint("a red string");
-    /// link_string.hyperlink("https://www.example.com");
+    /// let link_string = Red.paint("a red string").hyperlink("https://www.example.com");
     /// println!("{}", link_string);
     /// ```
     /// Should show a red-painted string which, on terminals
     /// that support it, is a clickable hyperlink.
-    pub fn hyperlink<I>(&mut self, url: I)
+    pub fn hyperlink<I>(mut self, url: I) -> Self
     where
         I: Into<Cow<'a, S>>,
     {
         self.oscontrol = Some(OSControl::Link { url: url.into() });
+        self
     }
 
     /// Get any URL associated with the string
@@ -461,8 +461,9 @@ mod tests {
 
     #[test]
     fn hyperlink() {
-        let mut styled = Red.paint("Link to example.com.");
-        styled.hyperlink("https://example.com");
+        let styled = Red
+            .paint("Link to example.com.")
+            .hyperlink("https://example.com");
         assert_eq!(
             styled.to_string(),
             "\x1B[31m\x1B]8;;https://example.com\x1B\\Link to example.com.\x1B]8;;\x1B\\\x1B[0m"
@@ -472,9 +473,11 @@ mod tests {
     #[test]
     fn hyperlinks() {
         let before = Green.paint("Before link. ");
-        let mut link = Blue.underline().paint("Link to example.com.");
+        let link = Blue
+            .underline()
+            .paint("Link to example.com.")
+            .hyperlink("https://example.com");
         let after = Green.paint(" After link.");
-        link.hyperlink("https://example.com");
 
         // Assemble with link by itself
         let joined = AnsiStrings(&[link.clone()]).to_string();


### PR DESCRIPTION
The API for modifying a string to contain a hyperlink used in #47
behaves different than most of our `Style`-driven APIs that basically
all work through method chaining.

As an alternative I propose we change the signature to take the
`AnsiGenericString` by value and modify it in place. This feels more
expressive for quickly building out a styled string with a link.
One downside compared to a modifying setter API is that it takes a
more tokens to do conditional modification with an `if` expression.

cc @fdncred, @mhelsley
