### PR TITLE
Bump version for 0.49 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 rust-version = "1.62.1"
 license = "MIT"
 name = "nu-ansi-term"
-version = "0.48.0"
+version = "0.49.0"
 repository = "https://github.com/nushell/nu-ansi-term"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ This crate works with [Cargo](http://crates.io). Add the following to your `Carg
 
 ```toml
 [dependencies]
-nu-ansi-term = "0.47"
+nu-ansi-term = "0.49"
 
 # optional gnu-legacy mode to have two digit instead of one digit styles
-nu-ansi-term = { version="0.47", features=["gnu_legacy"] }
+nu-ansi-term = { version="0.49", features=["gnu_legacy"] }
 ```
 
 ## Basic usage


### PR DESCRIPTION
Should include the more friendly API breakage from #47
Still a breaking change compared to 0.47 based on #40
