### PR TITLE
Remove unused import

### DIFF
--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -1,6 +1,5 @@
 // Code liberally borrowed from here
 // https://github.com/navierr/coloriz
-use std::u32;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Rgb {
     /// Red


### PR DESCRIPTION
The import triggers `clippy::legacy_numeric_constants`.