### PR TITLE
Update to windows-sys 0.60

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 rust-version = "1.62.1"
 license = "MIT"
 name = "nu-ansi-term"
-version = "0.50.1"
+version = "0.50.2"
 repository = "https://github.com/nushell/nu-ansi-term"
 
 [lib]
@@ -24,7 +24,7 @@ gnu_legacy = []
 serde = { version="1.0.152", features=["derive"], optional=true }
 
 [target.'cfg(windows)'.dependencies.windows]
-version = "0.52.0"
+version = "0.60.0"
 package = "windows-sys"
 features = [
     "Win32_Foundation",

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -28,8 +28,8 @@ pub fn enable_ansi_support() -> Result<(), u32> {
             FILE_SHARE_WRITE,
             std::ptr::null_mut(), // SECURITY_ATTRIBUTES
             OPEN_EXISTING,
-            0, // FILE_FLAGS_AND_ATTRIBUTES
-            0, // hTemplateFile: HANDLE
+            0,                    // FILE_FLAGS_AND_ATTRIBUTES
+            std::ptr::null_mut(), // hTemplateFile: HANDLE
         );
         if console_handle == INVALID_HANDLE_VALUE {
             return Err(GetLastError());


### PR DESCRIPTION
I'd like to move all dependency of Cargo to the latest `windows-sys` since older versions don't support Arm64EC.