### PR TITLE
fix clippy doc warning

### DIFF
--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -66,7 +66,7 @@ impl Rgb {
         Self::from_f32(x, x, x)
     }
 
-    /// Creates a new [Rgb] color from a [HSL] color
+    // Creates a new [Rgb] color from a [HSL] color
     // pub fn from_hsl(hsl: HSL) -> Self {
     //     if hsl.s == 0.0 {
     //         return Self::gray_f32(hsl.l);


### PR DESCRIPTION
Fixed this problem. Let's keep the comments for now.
```
error: empty lines after doc comment
  --> src\rgb.rs:69:5
   |
69 | /     /// Creates a new [Rgb] color from a [HSL] color
...  |
96 | |
   | |_^
97 |       /// Computes the linear interpolation between `self` and `other` for `t`
98 |       pub fn lerp(&self, other: Self, t: f32) -> Self {
   |       ----------- the comment documents this function
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#empty_line_after_doc_comments
   = note: `-D clippy::empty-line-after-doc-comments` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::empty_line_after_doc_comments)]`
   = help: if the empty lines are unintentional, remove them
help: if the doc comment should not document function `lerp` then comment it out
   |
69 |     // /// Creates a new [Rgb] color from a [HSL] color
   |     ++

error: could not compile `nu-ansi-term` (lib) due to 1 previous error
```