### PR TITLE
chore: widen windows-sys dependency version range

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ gnu_legacy = []
 serde = { version="1.0.152", features=["derive"], optional=true }
 
 [target.'cfg(windows)'.dependencies.windows]
-version = "0.60.0"
+version = ">=0.59, <=0.61"
 package = "windows-sys"
 features = [
     "Win32_Foundation",


### PR DESCRIPTION
#66 updated the `windows-sys` dependency to `0.60.0` to allow for ARM64EC support, but ARM64EC support was originally introduced in `0.59.0`. Since both `windows-sys` and `nu-ansi-term` are both widely used, it's good to have a larger dependency range to avoid duplicate dependencies in user's buildgraphs (and triggering `clippy::multiple-crate-versions`). There's precedent for doing this in many crates:

* https://lib.rs/crates/windows-sys/rev
* https://lib.rs/crates/windows/rev