### PR TITLE
Replace windows-sys dependency with generated bindings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,16 +23,10 @@ gnu_legacy = []
 [dependencies]
 serde = { version="1.0.152", features=["derive"], optional=true }
 
-[target.'cfg(windows)'.dependencies.windows]
-version = ">=0.59, <=0.61"
-package = "windows-sys"
-features = [
-    "Win32_Foundation",
-    "Win32_System_Console",
-    "Win32_Storage_FileSystem",
-    "Win32_Security"
-]
+[target.'cfg(windows)'.dependencies]
+windows-link = "0.2"
 
 [dev-dependencies]
 doc-comment = "0.3.3"
 serde_json = "1.0.94"
+windows-bindgen = "0.64"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,8 +251,11 @@ pub use display::*;
 
 mod write;
 
+#[cfg(windows)]
+mod win_bindings;
+#[cfg(windows)]
 mod windows;
-#[allow(unused_imports)]
+#[cfg(windows)]
 pub use crate::windows::*;
 
 mod util;

--- a/src/win_bindings.rs
+++ b/src/win_bindings.rs
@@ -1,0 +1,39 @@
+#![allow(
+    non_snake_case,
+    non_upper_case_globals,
+    non_camel_case_types,
+    dead_code,
+    clippy::all
+)]
+
+windows_link::link!("kernel32.dll" "system" fn CreateFileW(lpfilename : PCWSTR, dwdesiredaccess : u32, dwsharemode : FILE_SHARE_MODE, lpsecurityattributes : *const SECURITY_ATTRIBUTES, dwcreationdisposition : FILE_CREATION_DISPOSITION, dwflagsandattributes : FILE_FLAGS_AND_ATTRIBUTES, htemplatefile : HANDLE) -> HANDLE);
+windows_link::link!("kernel32.dll" "system" fn GetConsoleMode(hconsolehandle : HANDLE, lpmode : *mut CONSOLE_MODE) -> BOOL);
+windows_link::link!("kernel32.dll" "system" fn GetLastError() -> WIN32_ERROR);
+windows_link::link!("kernel32.dll" "system" fn SetConsoleMode(hconsolehandle : HANDLE, dwmode : CONSOLE_MODE) -> BOOL);
+pub type BOOL = i32;
+pub type CONSOLE_MODE = u32;
+pub const ENABLE_VIRTUAL_TERMINAL_PROCESSING: CONSOLE_MODE = 4u32;
+pub type FILE_ACCESS_RIGHTS = u32;
+pub type FILE_CREATION_DISPOSITION = u32;
+pub type FILE_FLAGS_AND_ATTRIBUTES = u32;
+pub const FILE_GENERIC_READ: FILE_ACCESS_RIGHTS = 1179785u32;
+pub const FILE_GENERIC_WRITE: FILE_ACCESS_RIGHTS = 1179926u32;
+pub type FILE_SHARE_MODE = u32;
+pub const FILE_SHARE_WRITE: FILE_SHARE_MODE = 2u32;
+pub type HANDLE = *mut core::ffi::c_void;
+pub const INVALID_HANDLE_VALUE: HANDLE = -1i32 as _;
+pub const OPEN_EXISTING: FILE_CREATION_DISPOSITION = 3u32;
+pub type PCWSTR = *const u16;
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct SECURITY_ATTRIBUTES {
+    pub nLength: u32,
+    pub lpSecurityDescriptor: *mut core::ffi::c_void,
+    pub bInheritHandle: BOOL,
+}
+impl Default for SECURITY_ATTRIBUTES {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+pub type WIN32_ERROR = u32;

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,3 +1,9 @@
+// ref: https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences#EXAMPLE_OF_ENABLING_VIRTUAL_TERMINAL_PROCESSING @@ https://archive.is/L7wRJ#76%
+use crate::win_bindings::{
+    CreateFileW, GetConsoleMode, GetLastError, SetConsoleMode, ENABLE_VIRTUAL_TERMINAL_PROCESSING,
+    FILE_GENERIC_READ, FILE_GENERIC_WRITE, FILE_SHARE_WRITE, INVALID_HANDLE_VALUE, OPEN_EXISTING,
+};
+
 /// Enables ANSI code support on Windows 10.
 ///
 /// This uses Windows API calls to alter the properties of the console that
@@ -6,19 +12,7 @@
 /// https://msdn.microsoft.com/en-us/library/windows/desktop/mt638032(v=vs.85).aspx
 ///
 /// Returns a `Result` with the Windows error code if unsuccessful.
-#[cfg(windows)]
 pub fn enable_ansi_support() -> Result<(), u32> {
-    // ref: https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences#EXAMPLE_OF_ENABLING_VIRTUAL_TERMINAL_PROCESSING @@ https://archive.is/L7wRJ#76%
-    use windows::w;
-    use windows::Win32::Foundation::GetLastError;
-    use windows::Win32::Foundation::INVALID_HANDLE_VALUE;
-    use windows::Win32::Storage::FileSystem::{CreateFileW, OPEN_EXISTING};
-    use windows::Win32::Storage::FileSystem::{
-        FILE_GENERIC_READ, FILE_GENERIC_WRITE, FILE_SHARE_WRITE,
-    };
-    use windows::Win32::System::Console::ENABLE_VIRTUAL_TERMINAL_PROCESSING;
-    use windows::Win32::System::Console::{GetConsoleMode, SetConsoleMode};
-
     unsafe {
         // ref: https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew
         // Using `CreateFileW("CONOUT$", ...)` to retrieve the console handle works correctly even if STDOUT and/or STDERR are redirected
@@ -55,3 +49,15 @@ pub fn enable_ansi_support() -> Result<(), u32> {
         Ok(())
     }
 }
+
+const CONOUT_WSTR: &[u16] = &[
+    36,
+    b'C' as u16,
+    b'O' as u16,
+    b'N' as u16,
+    b'O' as u16,
+    b'U' as u16,
+    b'T' as u16,
+    b'$' as u16,
+    0, // Null terminator
+];

--- a/tests/codegen.rs
+++ b/tests/codegen.rs
@@ -1,0 +1,48 @@
+use std::fs;
+
+use windows_bindgen::bindgen;
+
+#[test]
+fn gen_bindings() {
+    let existing = fs::read_to_string(BINDINGS).unwrap();
+
+    bindgen(INPUT).unwrap();
+
+    // Check the output is the same as before.
+    // Depending on the git configuration the file may have been checked out with `\r\n` newlines or
+    // with `\n`. Compare line-by-line to ignore this difference.
+    let mut new = fs::read_to_string(BINDINGS).unwrap();
+    if existing.contains("\r\n") && !new.contains("\r\n") {
+        new = new.replace("\n", "\r\n");
+    } else if !existing.contains("\r\n") && new.contains("\r\n") {
+        new = new.replace("\r\n", "\n");
+    }
+
+    assert_eq!(existing, new);
+    if !new.lines().eq(existing.lines()) {
+        panic!("generated file `{BINDINGS}` has been updated");
+    }
+}
+
+const INPUT: &[&str] = &[
+    "--no-deps",
+    "--etc",
+    "--out",
+    BINDINGS,
+    "--flat",
+    "--sys",
+    "--no-comment",
+    "--filter",
+    "GetLastError",
+    "INVALID_HANDLE_VALUE",
+    "CreateFileW",
+    "FILE_GENERIC_READ",
+    "FILE_GENERIC_WRITE",
+    "FILE_SHARE_WRITE",
+    "OPEN_EXISTING",
+    "GetConsoleMode",
+    "SetConsoleMode",
+    "ENABLE_VIRTUAL_TERMINAL_PROCESSING",
+];
+
+const BINDINGS: &str = "src/win_bindings.rs";


### PR DESCRIPTION
This avoids the substantial churn and large downloads from the windows-sys dependency in favor of generating checked in code using the windows-bindgen crate (which ultimately also generates the windows-sys code).

I've used a similar setup successfully in chrono, and it's generally pretty low maintenance.